### PR TITLE
Predicate Extension: Filtering notes by title

### DIFF
--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -32,6 +32,25 @@ extension NSPredicate {
         return NSCompoundPredicate(andPredicateWithSubpredicates: output)
     }
 
+    /// Returns a NSPredicate that will match a given Keyword in the Note's Title
+    ///
+    /// - Note: The Entity received by the NSPredicate's callback is expected to be a NSManagedObject (OR) a lower level instance.
+    ///         In macOS's scenario, we're receiving an XMLNode (referencing to the underlying CoreData structure).
+    ///         By invoking Value for Key we can extract the Note's Contents in any case. As long as it's a Note entity!
+    ///
+    public static func predicateForNotes(titleText: String) -> NSPredicate {
+        let normalizedKeyword = titleText.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+
+        return NSPredicate { entity, _ in
+            guard let note = entity as? NSObject, let content = note.value(forKey: "content") as? String else {
+                return false
+            }
+
+            let title = content.firstLine.folding(options: [.diacriticInsensitive, .caseInsensitive], locale: nil)
+            return title.contains(normalizedKeyword)
+        }
+    }
+
     /// Returns a NSPredicate that will match Notes with the specified `deleted` flag
     ///
     @objc(predicateForNotesWithDeletedStatus:)

--- a/Sources/SimplenoteSearch/Internal/String+Internal.swift
+++ b/Sources/SimplenoteSearch/Internal/String+Internal.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+
+// MARK: - Internal API(s)
+//
+extension String {
+
+    /// Returns the receiver's First Line
+    ///
+    var firstLine: String {
+        guard let newlineIndex = firstIndex(of: Character("\n")) else {
+            return self
+        }
+
+        return String(prefix(upTo: newlineIndex))
+    }
+}

--- a/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
+++ b/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
@@ -138,6 +138,45 @@ class NSPredicateSimplenoteTests: XCTestCase {
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
+    /// Verifies that `predicateForNotes(titleText:)` matches entities that contain the Keyword in their title, regardless of the diacritics
+    ///
+    func testPredicateForNotesWithTitleMatchesEntitiesWithKeywordInTheTitleIgnoringSpecialCharacters() {
+        let entity = MockupNote()
+        entity.content = "Some title with díácrïtīc chårâctërs"
+
+        let predicate = NSPredicate.predicateForNotes(titleText: "diâcritic characters")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `predicateForNotes(titleText:)` matches entities that contain the Keyword in their title, regardless of the case
+    ///
+    func testPredicateForNotesWithTitleMatchesEntitiesWithKeywordInTheTitleIgnoringCase() {
+        let entity = MockupNote()
+        entity.content = "SOME TiTLE HERE"
+
+        let predicate = NSPredicate.predicateForNotes(titleText: "tItle")
+        XCTAssertTrue(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `predicateForNotes(titleText:)` does not match entities that contain `keyword` in lines that aren't the first one
+    ///
+    func testPredicateForNotesWithTitleDoesNotMatchKeywordsContainedInLinesThatArentTheFirst() {
+        let entity = MockupNote()
+        entity.content = "Some title here\nkeyword\nkeyword\n\n\nkeyword"
+
+        let predicate = NSPredicate.predicateForNotes(titleText: "keyword")
+        XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+    /// Verifies that `predicateForNotes(titleText:)` doesn't crash when the Entity's Contents are nil
+    ///
+    func testPredicateForNotesWithTitleDoesNotCrashOnNilContent() {
+        let entity = MockupNote()
+        let predicate = NSPredicate.predicateForNotes(titleText: "keyword")
+        XCTAssertFalse(predicate.evaluate(with: entity))
+    }
+
+
     /// Verifies that `NSPredicate.predicateForNotes(deleted:)` matches notes with a Deleted status
     ///
     func testPredicateForNotesWithDeletedStatusMatchesDeletedNotes() {


### PR DESCRIPTION
### Fix
In this PR we're adding a new NSPredicate Extension API, which allows us to filter Notes by Title

### Test
Please verify via [this Simplenote PR](https://github.com/Automattic/SimplenoteSearch-Swift/pull/2)

### Release
These changes do not require release notes.
