### PR TITLE
Search Query

### DIFF
--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -5,31 +5,34 @@ import Foundation
 //
 extension NSPredicate {
 
-    /// Returns a collection of NSPredicates that will match, as a compound, a given Search Text
+    /// Returns a collection of NSPredicates that will match, as a compound, a given Search Query
     ///
-    @objc(predicateForSearchText:)
-    public static func predicateForNotes(searchText: String) -> NSPredicate {
-        let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
-        var output = [NSPredicate]()
-
-        for keyword in keywords where keyword.isEmpty == false {
-            guard let tag = keyword.lowercased().suffix(afterPrefix: lowercasedSearchOperatorForTags) else {
-                output.append( NSPredicate(format: "content CONTAINS[cd] %@", keyword) )
-                continue
+    @objc(predicateForSearchQuery:)
+    public static func predicateForNotes(query: SearchQuery) -> NSPredicate {
+        let predicates = query.items.compactMap { (item) -> NSPredicate? in
+            switch item {
+            case .keyword(let value):
+                return NSPredicate(format: "content CONTAINS[cd] %@", value)
+            case .tag(let value):
+                if value.isEmpty {
+                    return nil
+                }
+                return NSPredicate(format: "tags CONTAINS[cd] %@", formattedTag(for: value))
             }
-
-            guard !tag.isEmpty else {
-                continue
-            }
-
-            output.append( NSPredicate(format: "tags CONTAINS[cd] %@", formattedTag(for: tag)) )
         }
 
-        guard !output.isEmpty else {
+        guard !predicates.isEmpty else {
             return NSPredicate(value: true)
         }
 
-        return NSCompoundPredicate(andPredicateWithSubpredicates: output)
+        return NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
+    }
+
+    /// Returns a collection of NSPredicates that will match, as a compound, a given Search Query
+    ///
+    @objc(predicateForSearchText:)
+    public static func predicateForNotes(searchText: String) -> NSPredicate {
+        return predicateForNotes(query: SearchQuery(searchText: searchText))
     }
 
     /// Returns a NSPredicate that will match Notes with the specified `deleted` flag
@@ -74,7 +77,7 @@ extension NSPredicate {
         return NSPredicate(format: "tags MATCHES[n] %@", regex)
     }
 
-    /// Returns a NSPredicate that will match Tags with a given Keyword
+    /// Returns a NSPredicate that will match Tags with a given Query
     ///
     /// -   We'll always analyze the last token in the string
     ///     -   Whenever the last token contains `tag:`, we'll lookup Tags with names containing the payload, excluding exact matches
@@ -82,22 +85,31 @@ extension NSPredicate {
     ///     -   If the `tag:` operator has no actual payload, **every single tag** will be matched (Always True Predicate)
     ///
     @objc
-    public static func predicateForTag(keyword: String) -> NSPredicate {
-        let keywords = keyword.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
-        let last = keywords.last?.lowercased() ?? String()
-
-        guard let tag = last.suffix(afterPrefix: lowercasedSearchOperatorForTags) else {
-            return NSPredicate(format: "name CONTAINS[cd] %@", last)
-        }
-
-        guard tag.isEmpty == false else {
+    public static func predicateForTag(query: SearchQuery) -> NSPredicate {
+        guard let lastItem = query.items.last else {
             return NSPredicate(value: true)
         }
 
-        return NSCompoundPredicate(andPredicateWithSubpredicates: [
-            NSPredicate(format: "name CONTAINS[cd] %@", tag),
-            NSPredicate(format: "name <>[c] %@", tag)
-        ])
+        switch lastItem {
+        case .keyword(let value):
+            return NSPredicate(format: "name CONTAINS[cd] %@", value)
+        case .tag(let value):
+            guard value.isEmpty == false else {
+                return NSPredicate(value: true)
+            }
+
+            return NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "name CONTAINS[cd] %@", value),
+                NSPredicate(format: "name <>[c] %@", value)
+            ])
+        }
+    }
+
+    /// Returns a NSPredicate that will match Tags with a given Keyword
+    ///
+    @objc
+    public static func predicateForTag(keyword: String) -> NSPredicate {
+        return predicateForTag(query: SearchQuery(searchText: keyword))
     }
 }
 
@@ -111,11 +123,5 @@ private extension NSPredicate {
     static func formattedTag(for tag: String) -> String {
         let filtered = tag.replacingOccurrences(of: "\\", with: "\\\\").replacingOccurrences(of: "/", with: "\\/")
         return String(format: "\"%@\"", filtered)
-    }
-
-    /// Search Operator for Tags: Case Insensitive
-    ///
-    static var lowercasedSearchOperatorForTags: String {
-        String.searchOperatorForTags.lowercased()
     }
 }

--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -85,7 +85,7 @@ extension NSPredicate {
     ///     -   If the `tag:` operator has no actual payload, **every single tag** will be matched (Always True Predicate)
     ///
     @objc
-    public static func predicateForTag(query: SearchQuery) -> NSPredicate {
+    public static func predicateForTags(in query: SearchQuery) -> NSPredicate {
         guard let lastItem = query.items.last else {
             return NSPredicate(value: true)
         }
@@ -109,7 +109,7 @@ extension NSPredicate {
     ///
     @objc
     public static func predicateForTag(keyword: String) -> NSPredicate {
-        return predicateForTag(query: SearchQuery(searchText: keyword))
+        return predicateForTags(in: SearchQuery(searchText: keyword))
     }
 }
 

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// MARK: SearchQuery: wraps a search text
+//
+@objc
+public final class SearchQuery: NSObject {
+
+    /// Original search text
+    ///
+    @objc
+    public let searchText: String
+
+    /// A boolean value indicating if the query is empty
+    ///
+    @objc
+    public var isEmpty: Bool {
+        return items.isEmpty
+    }
+
+    /// Ordered list of query items found in a search text
+    ///
+    private(set) public var items: [SearchQueryItem] = []
+
+    /// Tags found in a search text
+    ///
+    @objc
+    public var tags: [String] {
+        return items.compactMap {
+            guard case let .tag(value) = $0, !value.isEmpty else {
+                return nil
+            }
+
+            return value
+        }
+    }
+
+    /// Keywords found in a search text
+    ///
+    @objc
+    public var keywords: [String] {
+        return items.compactMap {
+            guard case let .keyword(value) = $0 else {
+                return nil
+            }
+
+            return value
+        }
+    }
+
+    /// Init with a search text
+    ///
+    @objc
+    public init(searchText: String) {
+        self.searchText = searchText
+        super.init()
+        parse()
+    }
+
+    private func parse() {
+        let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
+
+        for keyword in keywords where keyword.isEmpty == false {
+            guard let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.lowercased()) else {
+                items.append(.keyword(keyword))
+                continue
+            }
+
+            items.append(.tag(tag))
+        }
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let object = object as? SearchQuery else {
+            return false
+        }
+
+        return items == object.items
+    }
+}

--- a/Sources/SimplenoteSearch/Query/SearchQueryItem.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQueryItem.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+// MARK: - SearchQueryItem
+//
+public enum SearchQueryItem: Equatable {
+    /// Keyword
+    ///
+    case keyword(String)
+
+    /// Tag
+    ///
+    case tag(String)
+}

--- a/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
+++ b/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import SimplenoteSearch
+
+// MARK: - SearchQuery Unit Tests
+//
+class SearchQueryTests: XCTestCase {
+
+    /// Verifies that query without a search text is empty
+    ///
+    func testQueryIsEmptyWhenTextIsEmpty() {
+        let query = SearchQuery(searchText: "")
+        XCTAssertTrue(query.isEmpty)
+    }
+
+    /// Verifies that query with only spaces and newlines is empty
+    ///
+    func testQueryIsEmptyWhenTextContainsOnlySpaces() {
+        let query = SearchQuery(searchText: " \n   \n\n  ")
+        XCTAssertTrue(query.isEmpty)
+    }
+
+    /// Verifies that multiple spaces between keywords are ignored
+    ///
+    func testQueryIgnoresSpaceBetweenKeywords() {
+        let query = SearchQuery(searchText: "    a      b    ")
+        let expected: [SearchQueryItem] = [
+            .keyword("a"),
+            .keyword("b"),
+        ]
+        XCTAssertEqual(query.items, expected)
+    }
+
+    /// Verifies that keywords are being split by whitespace
+    ///
+    func testQuerySplitsKeywordsByWhitespace() {
+        let query = SearchQuery(searchText: "a content! pre-lunch, mmmm")
+        let expected: [SearchQueryItem] = [
+            .keyword("a"),
+            .keyword("content!"),
+            .keyword("pre-lunch,"),
+            .keyword("mmmm"),
+        ]
+        XCTAssertEqual(query.items, expected)
+    }
+
+    /// Verifies that duplicate entries are kept
+    ///
+    func testQueryKeepsDuplicateKeywords() {
+        let query = SearchQuery(searchText: "a a")
+        let expected: [SearchQueryItem] = [
+            .keyword("a"),
+            .keyword("a")
+        ]
+        XCTAssertEqual(query.items, expected)
+    }
+
+    /// Verifies access to all keywords and non-empty tags
+    ///
+    func testQueryReturnsAllKeywordsAndTags() {
+        let query = SearchQuery(searchText: "a b tag:e tag: tag:f")
+        let expectedKeywords: [String] = [
+            "a",
+            "b"
+        ]
+        let expectedTags: [String] = [
+            "e",
+            "f"
+        ]
+        XCTAssertEqual(query.keywords, expectedKeywords)
+        XCTAssertEqual(query.tags, expectedTags)
+    }
+
+    /// Verifies tags are extracted from a search text
+    ///
+    func testQueryExtractsTags() {
+        let query = SearchQuery(searchText: "tag:a tag:b, keyword tag:pre-lunch")
+        let expected: [SearchQueryItem] = [
+            .tag("a"),
+            .tag("b,"),
+            .keyword("keyword"),
+            .tag("pre-lunch"),
+        ]
+        XCTAssertEqual(query.items, expected)
+    }
+
+    /// Verifies empty tags are kept
+    ///
+    func testQueryKeepsEmptyTags() {
+        let query = SearchQuery(searchText: "a b tag:a tag: tag:b")
+        let expected: [SearchQueryItem] = [
+            .keyword("a"),
+            .keyword("b"),
+            .tag("a"),
+            .tag(""),
+            .tag("b"),
+        ]
+        XCTAssertEqual(query.items, expected)
+    }
+}


### PR DESCRIPTION
### Details

In this PR we're adding a `SearchQuery` object. 
`SearchQuery` is initialised with a search text and provides an easy access to keywords and tags.

Can be tested via: https://github.com/Automattic/simplenote-ios/pull/965

@jleandroperez Mind taking a look! Thanks!

### Release
> These changes do not require release notes.