### PR TITLE
Prepare Simplenote Search to localize search keyword Tag:

### DIFF
--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -108,6 +108,13 @@ extension NSPredicate {
     /// Returns a NSPredicate that will match Tags with a given Keyword
     ///
     @objc
+    public static func predicateForTag(keyword: String, settings: SearchQuerySettings) -> NSPredicate {
+        return predicateForTags(in: SearchQuery(searchText: keyword, settings: settings))
+    }
+    
+    /// Returns a NSPredicate that will match Tags with a given SearchQuerty
+    ///
+    @objc
     public static func predicateForTag(query: SearchQuery) -> NSPredicate {
         return predicateForTags(in: query)
     }

--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -30,9 +30,9 @@ extension NSPredicate {
 
     /// Returns a collection of NSPredicates that will match, as a compound, a given Search Query
     ///
-    @objc(predicateForSearchText:)
-    public static func predicateForNotes(searchText: String) -> NSPredicate {
-        return predicateForNotes(query: SearchQuery(searchText: searchText))
+    @objc(predicateForSearchText:settings:)
+    public static func predicateForNotes(searchText: String, settings: SearchQuerySettings) -> NSPredicate {
+        return predicateForNotes(query: SearchQuery(searchText: searchText, settings: settings))
     }
 
     /// Returns a NSPredicate that will match Notes with the specified `deleted` flag
@@ -108,8 +108,8 @@ extension NSPredicate {
     /// Returns a NSPredicate that will match Tags with a given Keyword
     ///
     @objc
-    public static func predicateForTag(keyword: String) -> NSPredicate {
-        return predicateForTags(in: SearchQuery(searchText: keyword))
+    public static func predicateForTag(query: SearchQuery) -> NSPredicate {
+        return predicateForTags(in: query)
     }
 }
 

--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -30,7 +30,6 @@ extension NSPredicate {
 
     /// Returns a collection of NSPredicates that will match, as a compound, a given Search Query
     ///
-    @objc(predicateForSearchText:settings:)
     public static func predicateForNotes(searchText: String, settings: SearchQuerySettings) -> NSPredicate {
         return predicateForNotes(query: SearchQuery(searchText: searchText, settings: settings))
     }
@@ -107,7 +106,6 @@ extension NSPredicate {
 
     /// Returns a NSPredicate that will match Tags with a given Keyword
     ///
-    @objc
     public static func predicateForTag(keyword: String, settings: SearchQuerySettings) -> NSPredicate {
         return predicateForTags(in: SearchQuery(searchText: keyword, settings: settings))
     }

--- a/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSPredicate+Search.swift
@@ -111,13 +111,6 @@ extension NSPredicate {
     public static func predicateForTag(keyword: String, settings: SearchQuerySettings) -> NSPredicate {
         return predicateForTags(in: SearchQuery(searchText: keyword, settings: settings))
     }
-    
-    /// Returns a NSPredicate that will match Tags with a given SearchQuerty
-    ///
-    @objc
-    public static func predicateForTag(query: SearchQuery) -> NSPredicate {
-        return predicateForTags(in: query)
-    }
 }
 
 

--- a/Sources/SimplenoteSearch/Extensions/NSString+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSString+Search.swift
@@ -7,7 +7,7 @@ extension String {
 
     /// Returns the Search Operator we should recognize, when filtering out entities with a given Tag
     ///
-    public static let searchOperatorForTags = NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!")
+    public static let searchOperatorForTags = SearchQuerySettings.shared
 
 
     /// Returns a space

--- a/Sources/SimplenoteSearch/Extensions/NSString+Search.swift
+++ b/Sources/SimplenoteSearch/Extensions/NSString+Search.swift
@@ -4,12 +4,7 @@ import Foundation
 // MARK: - String Constants
 //
 extension String {
-
-    /// Returns the Search Operator we should recognize, when filtering out entities with a given Tag
-    ///
-    public static let searchOperatorForTags = SearchQuerySettings.shared
-
-
+    
     /// Returns a space
     ///
     public static let whitespace = " "

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -53,7 +53,6 @@ public final class SearchQuery: NSObject {
 
     /// Init with a search text
     ///
-    @objc
     public init(searchText: String, settings: SearchQuerySettings) {
         self.searchText = searchText
         self.settings = settings
@@ -93,13 +92,12 @@ public final class SearchQuery: NSObject {
     }
 }
 
-public class SearchQuerySettings: NSObject {
+public struct SearchQuerySettings {
     public let tagsKeyword: String
     public let localizedTagKeyword: String
     
     public init(tagsKeyword: String, localizedTagKeyword: String){
         self.tagsKeyword = tagsKeyword
         self.localizedTagKeyword = localizedTagKeyword
-        super.init()
     }
 }

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -60,11 +60,11 @@ public final class SearchQuery: NSObject {
         let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
 
         for keyword in keywords where keyword.isEmpty == false {
-            guard let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.lowercased()) else {
+            guard let tag = checkForTagOrLocalizedTag(with: keyword) else {
                 items.append(.keyword(keyword))
                 continue
             }
-
+            
             items.append(.tag(tag))
         }
     }

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -89,19 +89,13 @@ public final class SearchQuery: NSObject {
     }
 }
 
-public struct SearchQuerySettings {
+public class SearchQuerySettings: NSObject {
     public let tagsKeyword: String
     public let localizedTagKeyword: String
     
-    public init(tagsKeyword: String, localizedTagKeyword: String) {
+    public init(tagsKeyword: String, localizedTagKeyword: String){
         self.tagsKeyword = tagsKeyword
         self.localizedTagKeyword = localizedTagKeyword
-    }
-}
-
-public extension SearchQuerySettings {
-    static var shared: SearchQuerySettings {
-        SearchQuerySettings(tagsKeyword: "tag:",
-                            localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+        super.init()
     }
 }

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -68,6 +68,17 @@ public final class SearchQuery: NSObject {
             items.append(.tag(tag))
         }
     }
+    
+    private func checkForTagOrLocalizedTag(with keyword: String) -> String? {
+        if let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.tagsKeyword.lowercased()) {
+            return tag
+        }
+        if let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.localizedTagKeyword.lowercased()) {
+            return tag
+        }
+        
+        return nil
+    }
 
     public override func isEqual(_ object: Any?) -> Bool {
         guard let object = object as? SearchQuery else {

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -46,12 +46,17 @@ public final class SearchQuery: NSObject {
             return value
         }
     }
+    
+    /// Localized Tag search operator seach settings
+    ///
+    public var settings: SearchQuerySettings
 
     /// Init with a search text
     ///
     @objc
-    public init(searchText: String) {
+    public init(searchText: String, settings: SearchQuerySettings) {
         self.searchText = searchText
+        self.settings = settings
         super.init()
         parse()
     }
@@ -70,10 +75,10 @@ public final class SearchQuery: NSObject {
     }
     
     private func checkForTagOrLocalizedTag(with keyword: String) -> String? {
-        if let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.tagsKeyword.lowercased()) {
+        if let tag = keyword.lowercased().suffix(afterPrefix: settings.tagsKeyword.lowercased()) {
             return tag
         }
-        if let tag = keyword.lowercased().suffix(afterPrefix: String.searchOperatorForTags.localizedTagKeyword.lowercased()) {
+        if let tag = keyword.lowercased().suffix(afterPrefix: settings.localizedTagKeyword.lowercased()) {
             return tag
         }
         

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -65,23 +65,22 @@ public final class SearchQuery: NSObject {
         let keywords = searchText.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: .whitespaces)
 
         for keyword in keywords where keyword.isEmpty == false {
-            guard let tag = checkForTagOrLocalizedTag(with: keyword) else {
+            guard let tag = extractTagKeyword(from:keyword) else {
                 items.append(.keyword(keyword))
                 continue
             }
-            
             items.append(.tag(tag))
         }
     }
     
-    private func checkForTagOrLocalizedTag(with keyword: String) -> String? {
-        if let tag = keyword.lowercased().suffix(afterPrefix: settings.tagsKeyword.lowercased()) {
-            return tag
-        }
-        if let tag = keyword.lowercased().suffix(afterPrefix: settings.localizedTagKeyword.lowercased()) {
-            return tag
-        }
+    private func extractTagKeyword(from keyword: String) -> String? {
+        let tagPrefixes = [settings.tagsKeyword.lowercased(), settings.localizedTagKeyword.lowercased()]
         
+        for prefix in tagPrefixes {
+            if let tag = keyword.lowercased().suffix(afterPrefix: prefix) {
+                return tag
+            }
+        }
         return nil
     }
 

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -77,3 +77,20 @@ public final class SearchQuery: NSObject {
         return items == object.items
     }
 }
+
+public struct SearchQuerySettings {
+    public let tagsKeyword: String
+    public let localizedTagKeyword: String
+    
+    public init(tagsKeyword: String, localizedTagKeyword: String) {
+        self.tagsKeyword = tagsKeyword
+        self.localizedTagKeyword = localizedTagKeyword
+    }
+}
+
+public extension SearchQuerySettings {
+    static var shared: SearchQuerySettings {
+        SearchQuerySettings(tagsKeyword: "tag:",
+                            localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+    }
+}

--- a/Sources/SimplenoteSearch/Query/SearchQuery.swift
+++ b/Sources/SimplenoteSearch/Query/SearchQuery.swift
@@ -49,7 +49,7 @@ public final class SearchQuery: NSObject {
     
     /// Localized Tag search operator seach settings
     ///
-    public var settings: SearchQuerySettings
+    public let settings: SearchQuerySettings
 
     /// Init with a search text
     ///

--- a/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
+++ b/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
@@ -5,6 +5,8 @@ import SimplenoteSearch
 // MARK: - NSPredicate+Search Unit Tests
 //
 class NSPredicateSimplenoteTests: XCTestCase {
+    
+    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain a single specified keyword
     ///
@@ -12,7 +14,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "some content here and maybe a keyword"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "keyword")
+        let predicate = NSPredicate.predicateForNotes(searchText: "keyword", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -22,7 +24,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "first second"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "    first       second")
+        let predicate = NSPredicate.predicateForNotes(searchText: "    first       second", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -31,7 +33,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForNotesWithSearchTextProducesOnePredicatePerWordAndDisregardNewlinesAndSpaces() {
         let keyword = "     lots of empty spaces   \n   \n  "
         let numberOfWords = 4
-        let predicate = NSPredicate.predicateForNotes(searchText: keyword) as! NSCompoundPredicate
+        let predicate = NSPredicate.predicateForNotes(searchText: keyword, settings: searchSettings) as! NSCompoundPredicate
 
         XCTAssertTrue(predicate.subpredicates.count == numberOfWords)
     }
@@ -42,7 +44,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "some keyword1 here and maybe another keyword2 there"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "keyword1 keyword2")
+        let predicate = NSPredicate.predicateForNotes(searchText: "keyword1 keyword2", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -52,7 +54,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "jamás esdrújula"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "jamas esdrujula")
+        let predicate = NSPredicate.predicateForNotes(searchText: "jamas esdrujula", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -62,7 +64,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "some content here and maybe a keyword"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "missing")
+        let predicate = NSPredicate.predicateForNotes(searchText: "missing", settings: searchSettings)
         XCTAssertFalse(predicate.evaluate(with: entity))
     }
 
@@ -72,7 +74,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.content = "keyword"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword", settings: searchSettings)
         XCTAssertFalse(predicate.evaluate(with: entity))
     }
 
@@ -82,7 +84,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.tags = "[ \"keyword\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -92,7 +94,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.tags = "[ \"esdrújula\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:esdrujula")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:esdrujula", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -102,7 +104,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.tags = "[ \"keyword\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -112,7 +114,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         let entity = MockupNote()
         entity.tags = "[ \"keyword\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:word")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:word", settings: searchSettings)
         XCTAssertFalse(predicate.evaluate(with: entity))
     }
 
@@ -123,7 +125,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         entity.content = "unmatched"
         entity.tags = "[ \"keyword\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else", settings: searchSettings)
         XCTAssertFalse(predicate.evaluate(with: entity))
     }
 
@@ -134,7 +136,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
         entity.content = "something else"
         entity.tags = "[ \"keyword\" ]"
 
-        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else something")
+        let predicate = NSPredicate.predicateForNotes(searchText: "tag:keyword else something", settings: searchSettings)
         XCTAssertTrue(predicate.evaluate(with: entity))
     }
 
@@ -246,8 +248,8 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordPerformsPartialMatches() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "45").evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "45", settings: searchSettings).evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:45", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches Tags with diacritic rules
@@ -255,9 +257,9 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordPerformsPartialDiacriticMatches() {
         let entity = MockupTag()
         entity.name = "esdrújula"
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "esdrujula").evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "TAG:esdrujula").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TAG:esdrújula").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "esdrujula", settings: searchSettings).evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "TAG:esdrujula", settings: searchSettings).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TAG:esdrújula", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` will ignore exact matches
@@ -265,8 +267,8 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordCompletelyIgnoresExactTagMatches() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:123456789").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TAG:123456789").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:123456789", settings: searchSettings).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TAG:123456789", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` won't match Tags that don't contain a given string
@@ -274,9 +276,9 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithNameWontMatchEntitiesWithoutTheTargetName() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "0").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:0").evaluate(with: entity))
-        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TaG:0").evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "0", settings: searchSettings).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "tag:0", settings: searchSettings).evaluate(with: entity))
+        XCTAssertFalse(NSPredicate.predicateForTag(keyword: "TaG:0", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` only performs lookup OPs over the last keyword
@@ -284,9 +286,9 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordIsOnlyInterestedInTheLastKeyword() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: entity.name!).evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored 45").evaluate(with: entity))
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored tag:45").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: entity.name!, settings: searchSettings).evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored 45", settings: searchSettings).evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "ignored alsoIgnored tag:45", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches Tags with names containing the full keyword (whenever there is no Tag Operator)
@@ -294,7 +296,7 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordPerformsFullMatchesWhenThereIsNoTagOperator() {
         let entity = MockupTag()
         entity.name = "123456789"
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "123456789").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "123456789", settings: searchSettings).evaluate(with: entity))
     }
 
     /// Verifies that `NSPredicate.predicateForTag(keyword:)` matches *everything* whenever the `tag:` operator has no payload
@@ -302,9 +304,9 @@ class NSPredicateSimplenoteTests: XCTestCase {
     func testPredicateForTagWithKeywordMatchesEverythingWheneverSearchTagOperatorHasNoPayload() {
         let entity = MockupTag()
         entity.name = nil
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:", settings: searchSettings).evaluate(with: entity))
 
         entity.name = "whatever"
-        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:").evaluate(with: entity))
+        XCTAssertTrue(NSPredicate.predicateForTag(keyword: "tag:", settings: searchSettings).evaluate(with: entity))
     }
 }

--- a/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
+++ b/Tests/SimplenoteSearchTests/Extensions/NSPredicateSimplenoteTests.swift
@@ -6,7 +6,7 @@ import SimplenoteSearch
 //
 class NSPredicateSimplenoteTests: XCTestCase {
     
-    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+    let searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
 
     /// Verifies that `NSPredicate.predicateForNotes(searchText:)` match entities that contain a single specified keyword
     ///

--- a/Tests/SimplenoteSearchTests/Extensions/NSStringSearchTests.swift
+++ b/Tests/SimplenoteSearchTests/Extensions/NSStringSearchTests.swift
@@ -5,6 +5,8 @@ import SimplenoteSearch
 // MARK: - String Simplenote Unit Tests
 //
 class StringSimplenoteTests: XCTestCase {
+    
+    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
 
     /// Verifies that `replaceLastWord(:)` returns the new word, whenever the receiver was empty
     ///
@@ -35,22 +37,22 @@ class StringSimplenoteTests: XCTestCase {
     ///
     func testSuffixAfterPrefixReturnsNilWheneverTheInputStringLacksSuchPrefix() {
         let sample = "This is a sample of some random string without the tag operator"
-        XCTAssertNil(sample.suffix(afterPrefix: .searchOperatorForTags))
+        XCTAssertNil(sample.suffix(afterPrefix: searchSettings.tagsKeyword))
     }
 
     /// Verifies that Suffix after Prefix returns an empty string, whenever there is no actual Payload
     ///
     func testSuffixAfterPrefixReturnsNilWheneverTheTagSearchOperatorHasAnEmptyKeyword() {
-        let sample = String.searchOperatorForTags
-        XCTAssertEqual(sample.suffix(afterPrefix: .searchOperatorForTags), "")
+        let sample = searchSettings.tagsKeyword
+        XCTAssertEqual(sample.suffix(afterPrefix: searchSettings.tagsKeyword), "")
     }
 
     /// Verifies that Suffix after Prefix returns the payload right after the first occurrence of such suffix
     ///
     func testSuffixAfterPrefixReturnsTheRightHandSideStringAfterTheTagSearchOperator() {
         let expected = "somenameforatag"
-        let sample = String.searchOperatorForTags + expected
+        let sample = searchSettings.tagsKeyword + expected
 
-        XCTAssertEqual(sample.suffix(afterPrefix: .searchOperatorForTags), expected)
+        XCTAssertEqual(sample.suffix(afterPrefix: searchSettings.tagsKeyword), expected)
     }
 }

--- a/Tests/SimplenoteSearchTests/Extensions/NSStringSearchTests.swift
+++ b/Tests/SimplenoteSearchTests/Extensions/NSStringSearchTests.swift
@@ -6,7 +6,7 @@ import SimplenoteSearch
 //
 class StringSimplenoteTests: XCTestCase {
     
-    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+    let searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
 
     /// Verifies that `replaceLastWord(:)` returns the new word, whenever the receiver was empty
     ///

--- a/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
+++ b/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
@@ -5,7 +5,7 @@ import SimplenoteSearch
 //
 class SearchQueryTests: XCTestCase {
 
-    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+    let searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
     
     /// Verifies that query without a search text is empty
     ///

--- a/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
+++ b/Tests/SimplenoteSearchTests/Query/SearchQueryTests.swift
@@ -5,24 +5,26 @@ import SimplenoteSearch
 //
 class SearchQueryTests: XCTestCase {
 
+    var searchSettings = SearchQuerySettings(tagsKeyword: "tag:", localizedTagKeyword: NSLocalizedString("tag:", comment: "Search Operator for tags. Please preserve the semicolons when translating!"))
+    
     /// Verifies that query without a search text is empty
     ///
     func testQueryIsEmptyWhenTextIsEmpty() {
-        let query = SearchQuery(searchText: "")
+        let query = SearchQuery(searchText: "", settings: searchSettings)
         XCTAssertTrue(query.isEmpty)
     }
 
     /// Verifies that query with only spaces and newlines is empty
     ///
     func testQueryIsEmptyWhenTextContainsOnlySpaces() {
-        let query = SearchQuery(searchText: " \n   \n\n  ")
+        let query = SearchQuery(searchText: " \n   \n\n  ", settings: searchSettings)
         XCTAssertTrue(query.isEmpty)
     }
 
     /// Verifies that multiple spaces between keywords are ignored
     ///
     func testQueryIgnoresSpaceBetweenKeywords() {
-        let query = SearchQuery(searchText: "    a      b    ")
+        let query = SearchQuery(searchText: "    a      b    ", settings: searchSettings)
         let expected: [SearchQueryItem] = [
             .keyword("a"),
             .keyword("b"),
@@ -33,7 +35,7 @@ class SearchQueryTests: XCTestCase {
     /// Verifies that keywords are being split by whitespace
     ///
     func testQuerySplitsKeywordsByWhitespace() {
-        let query = SearchQuery(searchText: "a content! pre-lunch, mmmm")
+        let query = SearchQuery(searchText: "a content! pre-lunch, mmmm", settings: searchSettings)
         let expected: [SearchQueryItem] = [
             .keyword("a"),
             .keyword("content!"),
@@ -46,7 +48,7 @@ class SearchQueryTests: XCTestCase {
     /// Verifies that duplicate entries are kept
     ///
     func testQueryKeepsDuplicateKeywords() {
-        let query = SearchQuery(searchText: "a a")
+        let query = SearchQuery(searchText: "a a", settings: searchSettings)
         let expected: [SearchQueryItem] = [
             .keyword("a"),
             .keyword("a")
@@ -57,7 +59,7 @@ class SearchQueryTests: XCTestCase {
     /// Verifies access to all keywords and non-empty tags
     ///
     func testQueryReturnsAllKeywordsAndTags() {
-        let query = SearchQuery(searchText: "a b tag:e tag: tag:f")
+        let query = SearchQuery(searchText: "a b tag:e tag: tag:f", settings: searchSettings)
         let expectedKeywords: [String] = [
             "a",
             "b"
@@ -73,7 +75,7 @@ class SearchQueryTests: XCTestCase {
     /// Verifies tags are extracted from a search text
     ///
     func testQueryExtractsTags() {
-        let query = SearchQuery(searchText: "tag:a tag:b, keyword tag:pre-lunch")
+        let query = SearchQuery(searchText: "tag:a tag:b, keyword tag:pre-lunch", settings: searchSettings)
         let expected: [SearchQueryItem] = [
             .tag("a"),
             .tag("b,"),
@@ -86,7 +88,7 @@ class SearchQueryTests: XCTestCase {
     /// Verifies empty tags are kept
     ///
     func testQueryKeepsEmptyTags() {
-        let query = SearchQuery(searchText: "a b tag:a tag: tag:b")
+        let query = SearchQuery(searchText: "a b tag:a tag: tag:b", settings: searchSettings)
         let expected: [SearchQueryItem] = [
             .keyword("a"),
             .keyword("b"),


### PR DESCRIPTION
### Fix
This PR is part of a couple of PRs that are going to fix [Simplenote iOS issue 860](https://github.com/Automattic/simplenote-ios/issues/860) This PR specifically lays the ground work in Simplenote Search so that the changes that need to be done in Simplenote iOS will work.

What this PR covers:
- Creation of a SearchQuerySettings struct that contains the basic search key and the localized string
- Changes the tag search query string to use SearchQuerySettings instead of the current string
- Adds a method to check for the localized tag
- Implements that method when the search keywords are added

### Test
For this PR to functionally work it will need to be tested in combination with the Simplenote iOS PR (still to be made, will update with link once created) 

To test:
1. setup the Simplenote iOS branch linked to above
2. To the localized strings for a language, add a new translation pair, key "tag:" and translated to the supported language of your choice (I added mine to localizeableStrings (French) with this key
`"tag:" = "étiquette:";`
3. While the device/simulator is still set to English, run the app and go to search.  Type in tag: and then enter a tag to search, it should work.  Put in the local tag, it should not work.
4. Change the device language to your chosen language that you added the key for, and return to search.  Try searching for a tag just by name, try searching for a tag with they base keyword tag:, and try searching for a tag using the localized version of the tag key étiquette (or what ever translation you are using.  All three should work, but with the localized tag when the results appear you will see the results change:

<img width="300px" src="https://cdn-std.droplr.net/files/acc_593859/DOrN20" />

### Release
These changes do not require release notes.
